### PR TITLE
fix to allow compiling on 32-bit platforms

### DIFF
--- a/sampling/rng.h
+++ b/sampling/rng.h
@@ -61,7 +61,7 @@ class RNG {
     return (xorshifted >> rot) | (xorshifted << ((-rot) & 31));
   }
   double GetUniformFloat() {
-    static constexpr double S = static_cast<double>(1.0/(1ul<<32));
+    static constexpr double S = static_cast<double>(1.0/(uint_fast64_t(0x100000000)));
     return GetUniformInt() * S;
   }
 


### PR DESCRIPTION
The code fails to compile in 32-bit mode (e.g. emscripten) because `1ul<<32` can't be stored in an unsigned long, and then the `constexpr` fails. This seems to fix it.